### PR TITLE
Example Tomcat context.xml

### DIFF
--- a/context.xml
+++ b/context.xml
@@ -1,0 +1,9 @@
+<!-- Sample Tomcat context.xml which configures Tomcat's session manager to persist to Redis -->
+<Context>
+  <Loader loaderClass="org.springframework.instrument.classloading.tomcat.TomcatInstrumentableClassLoader"/>
+  <Valve className="com.gopivotal.manager.SessionFlushValve" />
+  <Manager className="org.apache.catalina.session.PersistentManager">
+    <!-- See https://github.com/CodeBloom/session-managers#configuration for more options -->
+    <Store className="com.gopivotal.manager.redis.RedisStore" uri="redis://username:password@localhost:6379/0" />
+  </Manager>
+</Context>


### PR DESCRIPTION
Added an example Tomcat context.xml which can be used to persist Tomcat's sessions to a Redis server
