### PR TITLE
Added support for Redis-backed sessions to dockerfile

### DIFF
--- a/dockerfiles/standalone/.gitignore
+++ b/dockerfiles/standalone/.gitignore
@@ -1,1 +1,2 @@
 /rice-standalone.war
+/redis-store.jar

--- a/dockerfiles/standalone/Dockerfile
+++ b/dockerfiles/standalone/Dockerfile
@@ -6,6 +6,7 @@ ENV MYSQL_DRIVER_URL https://repo1.maven.org/maven2/mysql/mysql-connector-java/5
 ENV TOMCAT_INSTRUMENT_URL https://repo1.maven.org/maven2/org/springframework/spring-instrument-tomcat/4.2.2.RELEASE/spring-instrument-tomcat-4.2.2.RELEASE.jar
 
 COPY rice-standalone.war $CATALINA_HOME/webapps/ROOT.war
+COPY redis-store.jar $CATALINA_HOME/lib/redis-store.jar
 
 RUN rm -rf $CATALINA_HOME/webapps/ROOT \
     && mkdir $CATALINA_HOME/webapps/ROOT \

--- a/dockerfiles/standalone/README.md
+++ b/dockerfiles/standalone/README.md
@@ -2,7 +2,10 @@ To build:
 
 First make sure there is a copy of the rice war in the directory with the name
 "rice-standalone.war", there is a helper script named "copy-war.sh" which you
-can look at.
+can look at. *Note:* Until the customized copy of the session-managers
+dependency can be uploaded to a Maven repository you will need to
+[check it out](https://github.com/CodeBloom/session-managers) and install it
+locally before you can fully prepare this Docker image.  To build the image:
 
 ```docker build -t rice-standalone .```
 
@@ -12,3 +15,7 @@ To run:
 
 Where ~/kuali-appconfig in this case is where your common-config.xml,
 log4j.properties, and rice.jks files are located
+
+If you would like to use Redis-backed sessions which will survive the Docker container restarting, you should create a context.xml file similar to the one [found in the root](../../context.xml) which is configured to point to your Redis instance.  From there you should mount the file in the Docker container at `/usr/local/tomcat/conf/context.xml` like so:
+
+```docker run -it --rm -v ~/kuali-appconfig:/config -v ~/kuali-appconfig/context.xml:/usr/local/tomcat/conf/context.xml --add-host="localhost:10.0.2.2" -p 8080 rice-standalone```

--- a/dockerfiles/standalone/copy-war.sh
+++ b/dockerfiles/standalone/copy-war.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-cp ~/.m2/repository/org/kuali/rice/rice-standalone/2.6.0-M1-SNAPSHOT/rice-standalone-2.6.0-M1-SNAPSHOT.war rice-standalone.war
+cp ~/.m2/repository/org/kuali/rice/rice-standalone/2.6.0-M1-SNAPSHOT/rice-standalone-2.6.0-M1-SNAPSHOT.war rice-standalone.war 
+cp ~/.m2/repository/com/gopivotal/manager/redis-store/1.3.0.BUILD-SNAPSHOT/redis-store-1.3.0.BUILD-SNAPSHOT.jar redis-store.jar 


### PR DESCRIPTION
Modified scripts to fetch the necessary JAR for Redis-backed sessions and instructions on how to configure the Docker container so it will persist Tomcat's sessions to Redis.
